### PR TITLE
Feat select older versions

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-APP_REPO_URL=https://github.com/TejInaco/test-tmc-ui.git
-CATALOG_REPO_URL=https://github.com/TejInaco/example-catalog.git
+APP_REPO_URL=https://github.com/wot-oss/tmc-ui.git
+CATALOG_REPO_URL=https://github.com/wot-oss/example-catalog.git
 SERVER_AVAILABLE=false

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,8 +6,8 @@ if [ -f ".env" ]; then
 	set +a
 fi
 
-: "${APP_REPO_URL:=https://github.com/TejInaco/test-tmc-ui.git}"
-: "${CATALOG_REPO_URL:=https://github.com/TejInaco/example-catalog.git}"
+: "${APP_REPO_URL:=https://github.com/wot-oss/tmc-ui.git}"
+: "${CATALOG_REPO_URL:=https://github.com/wot-oss/example-catalog.git}"
 : "${SERVER_AVAILABLE:=false}"
 
 log_info() {

--- a/src/components/GridList.tsx
+++ b/src/components/GridList.tsx
@@ -50,6 +50,7 @@ const GridList: React.FC<{
     : null;
 
   if (loading) return <div className="p-4 text-textValue">Loading...</div>;
+
   if (error)
     return (
       <div className="p-4">
@@ -100,7 +101,8 @@ const GridList: React.FC<{
                       </p>
 
                       <p className="mt-1 truncate text-sm text-textLabel">
-                        Number of Versions available: {itemTM.versions.length}
+                        {itemTM.versions.length} Version{itemTM.versions.length > 1 ? 's' : ''}{' '}
+                        available
                       </p>
                     </div>
                     <div className="flex-1">

--- a/src/components/GridList.tsx
+++ b/src/components/GridList.tsx
@@ -38,16 +38,15 @@ const GridList: React.FC<{
   error: string | null;
   deploymentType: DeploymentType;
 }> = ({ items, loading, error, deploymentType }) => {
-  __DEBUG__
-    ? console.warn(
-        'Rendering GridList with items:',
-        items,
-        'loading:',
-        loading,
-        'deploymenType:',
-        deploymentType,
-      )
-    : null;
+  __DEBUG__ &&
+    console.warn(
+      'Rendering GridList with items:',
+      items,
+      'loading:',
+      loading,
+      'deploymenType:',
+      deploymentType,
+    );
 
   if (loading) return <div className="p-4 text-textValue">Loading...</div>;
 

--- a/src/components/base/Dropdown.tsx
+++ b/src/components/base/Dropdown.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Select } from '@headlessui/react';
+interface IDropdownProps {
+  id: string;
+  label: string;
+  options: { key: string; value: string }[];
+  value?: string;
+  onChange?: (value: string) => void;
+  className?: string;
+}
+
+const Dropdown: React.FC<IDropdownProps> = (props) => {
+  return (
+    <Select
+      id={props.id}
+      name={props.label}
+      aria-label={props.label}
+      value={props.value}
+      onChange={(e) => props.onChange?.(e.target.value)}
+      className={props.className}
+    >
+      {props.options.map((option, i) => {
+        return (
+          <option
+            key={`${option.key} + ${i}`}
+            className="text-sm font-normal tracking-normal text-textValue"
+            value={option.key}
+          >
+            {option.value}
+          </option>
+        );
+      })}
+    </Select>
+  );
+};
+
+export default Dropdown;

--- a/src/components/base/Dropdown.tsx
+++ b/src/components/base/Dropdown.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { ChevronDownIcon } from '@heroicons/react/24/solid';
 import { Select } from '@headlessui/react';
+
 interface IDropdownProps {
   id: string;
   label: string;
@@ -7,30 +9,51 @@ interface IDropdownProps {
   value?: string;
   onChange?: (value: string) => void;
   className?: string;
+  wrapperClassName?: string;
+  chevronClassName?: string;
+  showChevron?: boolean;
 }
 
 const Dropdown: React.FC<IDropdownProps> = (props) => {
+  const wrapperClassName = [props.wrapperClassName, props.showChevron ? 'relative' : '']
+    .filter(Boolean)
+    .join(' ');
+
+  const selectClassName = [props.className, props.showChevron ? 'appearance-none pr-12' : '']
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <Select
-      id={props.id}
-      name={props.label}
-      aria-label={props.label}
-      value={props.value}
-      onChange={(e) => props.onChange?.(e.target.value)}
-      className={props.className}
-    >
-      {props.options.map((option, i) => {
-        return (
-          <option
-            key={`${option.key} + ${i}`}
-            className="text-sm font-normal tracking-normal text-textValue"
-            value={option.key}
-          >
-            {option.value}
-          </option>
-        );
-      })}
-    </Select>
+    <div className={wrapperClassName}>
+      <Select
+        id={props.id}
+        name={props.label}
+        aria-label={props.label}
+        value={props.value}
+        onChange={(e) => props.onChange?.(e.target.value)}
+        className={selectClassName}
+      >
+        {props.options.map((option, i) => {
+          return (
+            <option
+              key={`${option.key} + ${i}`}
+              className="text-sm font-normal tracking-normal text-textValue"
+              value={option.key}
+            >
+              {option.value}
+            </option>
+          );
+        })}
+      </Select>
+      {props.showChevron ? (
+        <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center">
+          <ChevronDownIcon
+            aria-hidden="true"
+            className={props.chevronClassName ?? 'h-5 w-5 text-textValue'}
+          />
+        </span>
+      ) : null}
+    </div>
   );
 };
 

--- a/src/components/base/FieldCard.tsx
+++ b/src/components/base/FieldCard.tsx
@@ -2,7 +2,7 @@ const FieldCard: React.FC<{ label: string; value: string }> = ({ label, value })
   return (
     <div className="mt-3 flex items-baseline gap-4">
       <h2 className="text-sm font-medium text-textLabel">{label}</h2>
-      <p className="text-2xl tracking-tight text-textValue">{value}</p>
+      {value && <p className="text-2xl tracking-tight text-textValue">{value}</p>}
     </div>
   );
 };

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -239,11 +239,11 @@ const Details = () => {
                       options={dropdownData}
                       value={selectedVersion}
                       onChange={handleVersionChange}
-                      className="self-center text-2xl font-normal tracking-normal text-textValue"
+                      className="self-center text-2xl tracking-normal text-textValue"
                     ></Dropdown>
                   </div>
                 </div>
-                <div className="flex items-center pl-10">
+                <div className="flex items-center gap-4 pl-10">
                   <FieldCard
                     label="Number of Versions"
                     value={item.versions?.length.toString() ?? '0'}

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from 'react';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
 import { MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { useParams, useLocation } from 'react-router-dom';
-import { THING_MODEL_ENDPOINT } from '../utils/constants';
 import defaultImage from '../assets/default-image.png';
 import FieldCard from '../components/base/FieldCard';
 import DialogAction from '../components/Dialog';
 import { fetchApiThingModel } from '../services/apiData';
 import type { ThingDescription } from 'wot-typescript-definitions';
 import { fetchLocalThingModel } from '../services/localData';
+import Dropdown from '../components/base/Dropdown';
 
 const DEFAULT_IMAGE_SRC = defaultImage;
 
@@ -56,6 +56,14 @@ const Details = () => {
 
   const [openWith, setOpenWith] = useState(false);
 
+  const [selectedVersion, setSelectedVersion] = useState<string>(
+    item.versions?.[0]?.version.model ?? '',
+  );
+  const dropdownData: { key: string; value: string }[] =
+    item?.versions?.map((version) => {
+      return { key: version.version.model, value: version.version.model };
+    }) ?? [];
+
   function useThingDetailsSections(td: ThingDescription | null) {
     return [
       { name: 'Properties', items: Object.keys(td?.properties ?? {}) },
@@ -64,30 +72,36 @@ const Details = () => {
     ];
   }
 
+  const fetchApi = async (fetchName: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchApiThingModel(__API_BASE__, fetchName);
+      setFullDescription(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load item.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchLocal = async (path: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchLocalThingModel(path);
+      setFullDescription(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load item.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
     setLoading(true);
-    const fetchApi = async () => {
-      try {
-        const data = await fetchApiThingModel(__API_BASE__, fetchName);
-        setFullDescription(data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load item.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    const fetchLocal = async () => {
-      try {
-        const fullPath: string = item.versions?.[0].links.content ?? '';
-        const data = await fetchLocalThingModel(fullPath);
-        setFullDescription(data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load item.');
-      } finally {
-        setLoading(false);
-      }
-    };
 
     if (!fetchName) {
       setError('Missing item id.');
@@ -107,24 +121,61 @@ const Details = () => {
     }
 
     if (deploymentType !== 'SERVER_AVAILABLE') {
-      fetchLocal();
+      const fullPath: string = item.versions?.[0].links.content ?? '';
+      fetchLocal(fullPath);
     } else {
-      fetchApi();
+      fetchApi(fetchName);
     }
   }, [fetchName, stateItem, item, deploymentType]);
 
-  const openFullDetails = () => {
+  const handleVersionChange = async (version: string) => {
+    setSelectedVersion(version);
+    const versionObject: Version | undefined = item.versions.find(
+      (v) => v.version.model === version,
+    );
+
+    if (!versionObject) {
+      setError(`Version "${version}" not found.`);
+      return;
+    }
+
+    const fullPath: string = versionObject.links.content ?? '';
+
+    if (deploymentType !== 'SERVER_AVAILABLE') {
+      fetchLocal(fullPath);
+    } else {
+      const res = await fetch(`${__API_BASE__}/${fullPath}`);
+      if (!res.ok) {
+        setError(`Failed to fetch version "${version}".`);
+        return;
+      }
+      const data = await res.json();
+      setFullDescription(data);
+    }
+  };
+
+  const openFullDetails = async (version: string) => {
     if (!fetchName || !__API_BASE__) return;
+    const versionObject: Version | undefined = item.versions.find(
+      (v) => v.version.model === version,
+    );
+
+    if (!versionObject) {
+      setError(`Version "${version}" not found.`);
+      return;
+    }
+    const fullPath: string = versionObject.links.content ?? '';
 
     if (deploymentType !== 'SERVER_AVAILABLE') {
       const baseUrl = import.meta.env.BASE_URL;
 
-      const url = `${window.location.origin}${baseUrl}${item.versions?.[0].links.content}`;
+      const url = `${window.location.origin}${baseUrl}${fullPath}`;
 
       window.open(url, '_blank', 'noopener,noreferrer');
       return;
     }
-    const url = `${__API_BASE__}/${THING_MODEL_ENDPOINT}/${encodeURIComponent(fetchName)}`;
+
+    const url = `${__API_BASE__}/${fullPath}`;
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
@@ -150,7 +201,7 @@ const Details = () => {
               <div className="mt-4 flex gap-3">
                 <button
                   type="button"
-                  onClick={openFullDetails}
+                  onClick={() => openFullDetails(selectedVersion)}
                   disabled={!fullDescription}
                   className="inline-flex items-center rounded-md bg-buttonPrimary px-3 py-2 text-sm font-semibold text-textWhite hover:bg-buttonOnHover focus-visible:outline focus-visible:outline-2 focus-visible:outline-buttonFocus disabled:cursor-not-allowed disabled:opacity-40"
                 >
@@ -168,16 +219,39 @@ const Details = () => {
 
             {/* Right: flexible content */}
             <div className="mt-0 flex-1 px-4 text-textGray sm:px-0">
-              <FieldCard label="Name" value={(item as ItemExtended).name ?? item.tmName ?? '—'} />
-              <FieldCard label="Author" value={item['schema:author']?.['schema:name'] ?? '—'} />
-              <FieldCard label="Repository" value={item.repo} />
-              <FieldCard label="MPN" value={item['schema:mpn']} />
               <FieldCard
-                label="Number of Versions"
-                value={item.versions?.length.toString() ?? '0'}
+                label="Manufacturer"
+                value={fullDescription?.['schema:manufacturer']?.['schema:name'] ?? item.tmName}
               />
-              <FieldCard label="Current Version" value={item.versions?.[0].version.model ?? '—'} />
-              <FieldCard label="Description" value={item.versions?.[0].description ?? '—'} />
+              <FieldCard
+                label="Author"
+                value={fullDescription?.['schema:author']?.['schema:name'] ?? '—'}
+              />
+              <FieldCard label="Title" value={(fullDescription?.title as string) ?? '—'} />
+              <FieldCard label="MPN" value={(fullDescription?.['schema:mpn'] as string) ?? '—'} />
+              <div className="mt-2 flex items-center gap-10 divide-gray-200 border-t border-gray-200 pt-2">
+                <div className="flex items-center gap-4">
+                  <FieldCard label="Current Version" value=""></FieldCard>
+                  <div className="flex items-center">
+                    <Dropdown
+                      label="version"
+                      id="currentVersion"
+                      options={dropdownData}
+                      value={selectedVersion}
+                      onChange={handleVersionChange}
+                      className="self-center text-2xl font-normal tracking-normal text-textValue"
+                    ></Dropdown>
+                  </div>
+                </div>
+                <div className="flex items-center pl-10">
+                  <FieldCard
+                    label="Number of Versions"
+                    value={item.versions?.length.toString() ?? '0'}
+                  />
+                </div>
+              </div>
+
+              <div className="mt-2 flex divide-y divide-gray-200 border-t border-gray-200"></div>
               <FieldCard label="ID" value={fullDescription?.id ?? '—'} />
               <section aria-labelledby="details-heading" className="mt-12">
                 <h2 id="details-heading" className="">

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -198,19 +198,36 @@ const Details = () => {
                   className="h-80 w-full rounded-lg object-contain p-4 shadow-md"
                 />
               </div>
-              <div className="mt-4 flex gap-3">
+              <div className="mt-5 flex w-full items-center justify-between gap-4">
+                <h1 className="shrink-0 text-sm font-medium uppercase tracking-[0.18em] text-textLabel">
+                  Version:
+                </h1>
+                <Dropdown
+                  label="version"
+                  id="currentVersion"
+                  options={dropdownData}
+                  value={selectedVersion}
+                  onChange={handleVersionChange}
+                  showChevron
+                  wrapperClassName="ml-auto w-full max-w-[13rem]"
+                  chevronClassName="h-5 w-5 text-textWhite"
+                  className="block h-10 w-full rounded-md border border-buttonBorder bg-buttonPrimary px-3 py-2 text-sm font-semibold text-textWhite shadow-sm transition hover:bg-buttonOnHover focus-visible:outline focus-visible:outline-2 focus-visible:outline-buttonFocus disabled:cursor-not-allowed disabled:opacity-40"
+                ></Dropdown>
+              </div>
+              <div className="mt-4 divide-y divide-gray-200 border-t border-gray-200"></div>
+              <div className="mt-4 flex w-full items-center gap-3">
                 <button
                   type="button"
                   onClick={() => openFullDetails(selectedVersion)}
                   disabled={!fullDescription}
-                  className="inline-flex items-center rounded-md bg-buttonPrimary px-3 py-2 text-sm font-semibold text-textWhite hover:bg-buttonOnHover focus-visible:outline focus-visible:outline-2 focus-visible:outline-buttonFocus disabled:cursor-not-allowed disabled:opacity-40"
+                  className="inline-flex flex-1 items-center justify-center rounded-md bg-buttonPrimary px-3 py-2 text-sm font-semibold text-textWhite hover:bg-buttonOnHover focus-visible:outline focus-visible:outline-2 focus-visible:outline-buttonFocus disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   Open full details
                 </button>
                 <button
                   type="button"
                   onClick={() => setOpenWith(true)}
-                  className="inline-flex items-center rounded-md border border-buttonBorder bg-buttonPrimary px-3 py-2 text-sm font-semibold text-textWhite hover:bg-buttonOnHover focus-visible:outline focus-visible:outline-2 focus-visible:outline-buttonFocus"
+                  className="inline-flex flex-1 items-center justify-center rounded-md border border-buttonBorder bg-buttonPrimary px-3 py-2 text-sm font-semibold text-textWhite hover:bg-buttonOnHover focus-visible:outline focus-visible:outline-2 focus-visible:outline-buttonFocus"
                 >
                   Open with …
                 </button>
@@ -229,27 +246,11 @@ const Details = () => {
               />
               <FieldCard label="Title" value={(fullDescription?.title as string) ?? '—'} />
               <FieldCard label="MPN" value={(fullDescription?.['schema:mpn'] as string) ?? '—'} />
-              <div className="mt-2 flex items-center gap-10 divide-gray-200 border-t border-gray-200 pt-2">
-                <div className="flex items-center gap-4">
-                  <FieldCard label="Current Version" value=""></FieldCard>
-                  <div className="flex items-center">
-                    <Dropdown
-                      label="version"
-                      id="currentVersion"
-                      options={dropdownData}
-                      value={selectedVersion}
-                      onChange={handleVersionChange}
-                      className="self-center text-2xl tracking-normal text-textValue"
-                    ></Dropdown>
-                  </div>
-                </div>
-                <div className="flex items-center gap-4 pl-10">
-                  <FieldCard
-                    label="Number of Versions"
-                    value={item.versions?.length.toString() ?? '0'}
-                  />
-                </div>
-              </div>
+              <FieldCard
+                label="Number of Versions"
+                value={item.versions?.length.toString() ?? '0'}
+              />
+              <FieldCard label="Current Version" value={selectedVersion} />
 
               <div className="mt-2 flex divide-y divide-gray-200 border-t border-gray-200"></div>
               <FieldCard label="ID" value={fullDescription?.id ?? '—'} />

--- a/src/services/dataLoader.ts
+++ b/src/services/dataLoader.ts
@@ -8,21 +8,18 @@ export async function dataLoader({ request }: LoaderFunctionArgs) {
 
   switch (deploymentType) {
     case 'SERVER_AVAILABLE': {
-      __DEBUG__ ? console.warn('Fetching inventory from local backend server...') : null;
+      __DEBUG__ && console.warn('Fetching inventory from local backend server...');
       const inventory = await fetchApiDataInventory(__API_BASE__, request);
       return { deploymentType, inventory };
     }
     case 'TYPE_TMC-UI-CATALOG': {
-      __DEBUG__
-        ? console.warn('Fetching inventory from a repository that contains a catalog...')
-        : null;
+      __DEBUG__ && console.warn('Fetching inventory from a repository that contains a catalog...');
+
       const inventory = await fetchLocalDataInventory(import.meta.env.BASE_URL);
       return { deploymentType, inventory };
     }
     case 'TYPE_CATALOG-TMC-UI': {
-      __DEBUG__
-        ? console.warn('Fetching inventory from local files in a catalog repository...')
-        : null;
+      __DEBUG__ && console.warn('Fetching inventory from local files in a catalog repository...');
       return { deploymentType, inventory: [] };
     }
   }

--- a/src/services/localData.ts
+++ b/src/services/localData.ts
@@ -43,7 +43,7 @@ export async function fetchLocalDataInventory(baseUrl: string): Promise<unknown[
 
   const json: unknown = await res.json();
 
-  __DEBUG__ ? console.warn('Fetched local inventory JSON:', json) : null;
+  __DEBUG__ && console.warn('Fetched local inventory JSON:', json);
 
   if (
     typeof json === 'object' &&
@@ -93,14 +93,14 @@ export async function fetchDataFromTxT(
 }
 
 export async function fetchLocalThingModel(fullpath: string): Promise<ThingDescription> {
-  __DEBUG__ ? console.warn('Fetching local Thing Model from path:', fullpath) : null;
+  __DEBUG__ && console.warn('Fetching local Thing Model from path:', fullpath);
 
   const basePath = import.meta.env.BASE_URL || '/';
   const urlBase = `${basePath}${fullpath.startsWith('/') ? fullpath.slice(1) : fullpath}`;
-  __DEBUG__ ? console.warn('Computed URL base for Thing Model:', urlBase) : null;
+  __DEBUG__ && console.warn('Computed URL base for Thing Model:', urlBase);
   const url = new URL(`${urlBase}`, window.location.origin);
 
-  __DEBUG__ ? console.warn('Fetching local Thing Model from URL:', url.toString()) : null;
+  __DEBUG__ && console.warn('Fetching local Thing Model from URL:', url.toString());
 
   const res = await fetch(url.toString());
   if (!res.ok) {
@@ -110,7 +110,7 @@ export async function fetchLocalThingModel(fullpath: string): Promise<ThingDescr
   }
 
   const json: unknown = await res.json();
-  __DEBUG__ ? console.warn('Fetched local Thing Model JSON:', json) : null;
+  __DEBUG__ && console.warn('Fetched local Thing Model JSON:', json);
 
   return json as ThingDescription;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,7 +29,7 @@ export const OPTIONS_LIST_SIZE = 10;
 
 export const SCROLL_THRESHOLD_PX = 64;
 
-export const INVENTORY_TIMEOUT_MS = 1000;
+export const INVENTORY_TIMEOUT_MS = 10000;
 
 export const REPOSITORY_CATALOG_DEFAULT_FOLDER = '.tmc/';
 


### PR DESCRIPTION
This PR will add a dropdown to select other versions of a given Thing Model.

Desire behaviour: When the user selects the details page of a given Thing Model, a dropdown showing the current version is visible. Options available are the versions of the Thing Model available.  
When selecting the an older version of the dropdown all data in the details page is updated with the Thing Model version.

Closes #10 