### PR TITLE
Filters Unavailable in dev mode

### DIFF
--- a/src/__tests__/config/viteConfig.test.ts
+++ b/src/__tests__/config/viteConfig.test.ts
@@ -101,6 +101,15 @@ describe('Vite config file test the setup of globals', () => {
     );
   });
 
+  test('routes API calls through the Vite proxy when serving locally', () => {
+    clearConfigEnv();
+    vi.stubEnv('VITE_SERVER_URL', 'http://localhost:8080');
+
+    const defines = resolveViteConfig('serve').define as ViteConfigDefines;
+
+    expect(defines.__API_BASE__).toBe(JSON.stringify('/__tmc_api__'));
+  });
+
   test('sets SERVER_AVAILABLE deployment globals when SERVER_AVAILABLE is true', () => {
     clearConfigEnv();
     vi.stubEnv('SERVER_AVAILABLE', 'true');

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   const remoteApiBase = env.VITE_SERVER_URL || `http://localhost:8080`;
-  const isDevServer = false; // TODO - Dev variable needs to be changed in production
+  const isDevServer = command === 'serve';
 
   const apiBase = isDevServer ? DEV_API_PROXY_PREFIX : remoteApiBase;
 


### PR DESCRIPTION
The vite config was not complete and it was not detecting dev mode and setting the wrong api base.

resolves #47 