### PR TITLE
Change TD to TM in the results text

### DIFF
--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -357,7 +357,7 @@ const Layout: React.FC<{
               <div className="mb-4 flex flex-wrap items-center gap-4 text-text-primary">
                 <p className="text-lg">
                   {resultCounts} result
-                  {resultCounts !== 1 ? 's' : ''} found in the catalog with {totalElements} TDs in
+                  {resultCounts !== 1 ? 's' : ''} found in the catalog with {totalElements} TMs in
                   total
                 </p>
                 <Button


### PR DESCRIPTION
simple text fix with no code impact. Without this, it reads `X results found in the catalog with Y TDs in total`